### PR TITLE
[fix] チャットルームの履歴表示とプッシュ通知機能を修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,22 +23,6 @@ $(function(){
     });
 });
 
-// プッシュ通知の許可申請
-if (!('Notification' in window)) {
-    alert('未対応のブラウザです');
-    }else{
-    // 許可を求める
-    Notification.requestPermission()
-        .then((permission) => {
-        if (permission == 'granted') {
-            var notification = new Notification('プッシュ通知が許可されました');
-        } else if (permission == 'denied') {
-            var notification = new Notification('プッシュ通知を拒否しました');
-        } else if (permission == 'default') {
-        }
-        });
-}
-
 // ページ上部に推移
 $(function() {
     $('#page_top').on('click',function(){
@@ -46,5 +30,26 @@ $(function() {
         scrollTop:0
         }, 800);
         return false;
+    });
+});
+
+// プッシュ通知の許可申請
+$(function(){
+    $('#push').on('click',function(){
+        if (!('Notification' in window)) {
+            alert('通知昨日は未対応のブラウザです');
+            }else{
+            alert("ブラウザの通知設定を有効にすることで、チャットメッセージを受信した時に、プッシュ通知を受け取ることができます");
+            // 許可を求める
+            Notification.requestPermission()
+                .then((permission) => {
+                if (permission == 'granted') {
+                    var notification = new Notification('通知が許可されました');
+                } else if (permission == 'denied') {
+                    var notification = new Notification('通知を拒否しました');
+                } else if (permission == 'default') {
+                }
+            });
+        };
     });
 });

--- a/app/assets/javascripts/channels/room.js
+++ b/app/assets/javascripts/channels/room.js
@@ -18,7 +18,6 @@ App.room = App.cable.subscriptions.create("RoomChannel", {
   },
 
   connected: function() {
-    // console.log("connected");
     // Called when the subscription is ready for use on the server
   },
 
@@ -27,10 +26,9 @@ App.room = App.cable.subscriptions.create("RoomChannel", {
   },
 
   received: function(data) {
-    console.log(data)
-    var received_user = $("#user_id").val();
-
-    if (received_user == data["user_id"]){
+    // var received_user = $("#user_id").val();
+    var current_user_id = $("#current_user_id").val();
+    if (current_user_id == data["user_id"]){
       $('<li>',{
         id: "message_id_" + data["message_id"],
         class: "right",
@@ -44,7 +42,7 @@ App.room = App.cable.subscriptions.create("RoomChannel", {
         text: data["content"],
       }).appendTo("#message_id_" + data["message_id"]);
       
-    } else if (received_user == data["receive_user_id"]){
+    } else if (current_user_id == data["receive_user_id"]){
       $('<li>',{
         id: "message_id_" + data["message_id"],
         class: "left",
@@ -58,23 +56,20 @@ App.room = App.cable.subscriptions.create("RoomChannel", {
         class: "created_time",
         text: data["created_time"],
       }).appendTo("#message_id_" + data["message_id"]);
-    }
-
+    };
     // 送りたい相手のidを取得してreceive時のcurrent_userと比較する
-    if (received_user == data["receive_user_id"]){
+    if (current_user_id == data["receive_user_id"]){
       var message = data["content"];
       App.room.notification(message);
-    } else if (received_user == data["user_id"]) {
+    } else if (current_user_id == data["user_id"]) {
       $('input').focus();
-
       $('#page_top').on('click',function(){
         $('body, html').animate({
         scrollBottom:0
         }, 800);
         return false;
       });
-      
-    }
+    };
     // Called when there's incoming data on the websocket for this channel
   },
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -124,6 +124,7 @@ td{
     padding: 5px 20px;
     font-size: 15px;
     background-color: lightyellow;
+    color: black;
 }
 
 ul{
@@ -169,6 +170,7 @@ ul{
 
 .time{
     font-size: 5px;
+    color: gray;
 }
 
 #preview{
@@ -213,4 +215,10 @@ a:hover{
 
 #page_top:hover{
     color: red;
+}
+
+.index_white_back{
+    width: 100%;
+    min-height: 700px;
+    background-color: white;
 }

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -78,3 +78,6 @@
     margin-left: 3px;
 }
 
+// .chat_title{
+//     padding-top: 20px;
+// }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -47,11 +47,6 @@
     background-color: whitesmoke;
 }
 
-.search_result{
-    width: 100%;
-    background-color: white;
-}
-
 #back_image{
     // height: 670px;
     background-image: url(user_index.jpg);
@@ -178,4 +173,8 @@ th{
     width: 70%;
     border-radius: 5px;
     box-shadow: 0px  0px 8px gray;
+}
+
+#push:hover{
+    color: red;
 }

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -8,7 +8,7 @@ class RoomChannel < ApplicationCable::Channel
   end
 
   def speak(data)
-    message = Message.new(content: data["message"], user_id: current_user.id, room_id: data["room_id"])
+    message = Message.new(content: data["message"], user_id: current_user.id, room_id: data["room_id"], receiver_id: data["receive_user_id"])
     message.save
     user_image = Refile.attachment_url(current_user, :user_image)
     created_time = message.created_at.strftime('%m/%d %H:%M')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,5 @@ class ApplicationController < ActionController::Base
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     end  
+
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -16,22 +16,20 @@ class RoomsController < ApplicationController
   end
 
   def show
-    @user_id = current_user.id
-    room = Room.find(params[:id])
-    @room_id = params[:id].to_i
-    @messages = room.messages
-    if room.host_id == current_user.id
-      @receive_user_id = room.member_id
+    @room = Room.find(params[:id])
+    @messages = @room.messages
+    if @room.host_id == current_user.id
+      @receive_user_id = @room.member_id
     else
-      @receive_user_id = room.host_id
+      @receive_user_id = @room.host_id
     end
     @receive_user = User.where(id: @receive_user_id).first
   end
 
   def index
-    @per = 8.to_i
-    @rooms_all = Room.where("(host_id = ?) OR (member_id = ?)", current_user,current_user)
-    @rooms = @rooms_all.page(params[:page]).per(@per)
+    user_messages = Message.where("(user_id = ?) OR (receiver_id = ?)", current_user, current_user)
+    @user_messages = user_messages.order(created_at: :desc)
+    @new_message = @user_messages.first
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,17 @@
 class UsersController < ApplicationController
   def index
-    @per = 20.to_i
     @q = User.ransack(params[:q])
     @users_all = @q.result(distinct: true)
+    @per = 20.to_i
     @users = @users_all.page(params[:page]).per(@per)
   end
 
   def show
     @user = User.find(params[:id])
     @rooms = Room.where("(host_id = ?) OR (member_id = ?)", current_user,current_user).order(created_at: :desc)
-    @count = 0
+    user_messages = Message.where("(user_id = ?) OR (receiver_id = ?)", current_user, current_user)
+    @user_messages = user_messages.order(created_at: :desc)
+    @new_message = @user_messages.first
     @count_all = 0
     @rooms.each do |room|
       if message = room.messages.order(created_at: :desc).first

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,7 @@
               <div class="col-xs-8 col-xs-offset-2">
                 <% if user_signed_in? %>
                   <div><%= current_user.name %>さんがログイン中</div>
+                  <input type="hidden" id="current_user_id" value="<%= current_user.id %>">
                 <% end %>
               </div>
             </div>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -2,47 +2,89 @@
     <div class="container">
         <div class="row">
             <div class="col-xs-8 col-xs-offset-2">
-                <div class="back_white">
-                    <span><%= current_user.name %>さんのチャットルーム一覧</span>
+                <div class="index_white_back">
+                    <span class="chat_title"><%= current_user.name %>さんのチャットルーム一覧</span>
                     <table class="table table-hover">
-                        <% @rooms.each do |room| %>
+                        <% if @user_messages.empty? == false %>
                             <tr>
+                                <% room = @new_message.room %>
                                 <% if room.host_id == current_user.id %>
                                     <% user = User.where(id: room.member_id).first %>
-                                <% else %>
-                                    <% user = User.where(id: room.host_id).first %>
-                                <% end %>
-
-                                <td>
-                                    <%= link_to room_path(room) do %>
-                                        <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
-                                    <% end %>
-                                </td>
-                                <td>
-                                    <%= link_to room_path(room) do %>
-                                        <%= user.name %>
-                                    <% end %>
-                                </td>
-                                <% if message = room.messages.order(created_at: :desc).first %>
+                                    <td class="col-xs-1">
+                                        <%= link_to room_path(room) do %>
+                                            <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                        <% end %>
+                                    </td>
                                     <td>
-                                        <div class="time"><%= message.created_at.strftime('%m/%d %H:%M') %></div>
-                                        <div id="new_message"><%= message.content.truncate(20) %></div>
+                                        <%= link_to room_path(room) do %>
+                                            <span class="name"><%= user.name %></span>
+                                        <% end %>
                                     </td>
                                 <% else %>
-                                    <td>メッセージはありません</td>
+                                    <% user = User.where(id: room.host_id).first %>
+                                    <td class="col-xs-1">
+                                        <%= link_to room_path(room) do %>
+                                            <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                        <% end %>
+                                    </td>
+                                    <td>
+                                        <%= link_to room_path(room) do %>
+                                            <span class="name"><%= user.name %></span>
+                                        <% end %>
+                                    </td>
                                 <% end %>
+                                <td>
+                                    <%= link_to room_path(room) do %>
+                                        <div class="time"><%= @new_message.created_at.strftime('%m/%d %H:%M') %></div>
+                                        <div id="new_message"><%= @new_message.content.truncate(20) %></div>
+                                    <% end %>
+                                </td>
                             </tr>
+                            <% room_id = @new_message.room_id %>
+                            <% old_message = @user_messages.where.not(room_id: room_id) %>
+                            <% message = old_message.order(created_at: :desc).first %>
+
+                            <% while old_message.count > 0 %>
+                                <tr>
+                                    <% room = message.room %>
+                                    <% if room.host_id == current_user.id %>
+                                        <% user = User.where(id: room.member_id).first %>
+                                        <td class="col-xs-1">
+                                            <%= link_to room_path(room) do %>
+                                                <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                            <% end %>
+                                        </td>
+                                        <td>
+                                            <%= link_to room_path(room) do %>
+                                                <span class="name"><%= user.name %></span>
+                                            <% end %>
+                                        </td>
+                                    <% else %>
+                                        <% user = User.where(id: room.host_id).first %>
+                                        <td class="col-xs-1">
+                                            <%= link_to room_path(room) do %>
+                                                <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                            <% end %>
+                                        </td>
+                                        <td>
+                                            <%= link_to room_path(room) do %>
+                                                <span class="name"><%= user.name %></span>
+                                            <% end %>
+                                        </td>
+                                    <% end %>
+                                    <td>
+                                        <%= link_to room_path(room) do %>
+                                            <div class="time"><%= message.created_at.strftime('%m/%d %H:%M') %></div>
+                                            <div id="new_message"><%= message.content.truncate(20) %></div>
+                                        <% end %>
+                                    </td>
+                                </tr>
+                                <% room_id = message.room_id %>
+                                <% old_message = old_message.where.not(room_id: room_id) %>
+                                <% message = old_message.order(created_at: :desc).first %>
+                            <% end %>
                         <% end %>
                     </table>
-                    <div class="page_count">
-                        <% if @rooms.count == 0 %>0 〜
-                        <% else %>
-                            <%= @rooms.current_page * @per - @per + 1 %>〜
-                        <% end %>
-                        <%= @rooms.current_page * @per - @per + @rooms.count %>件目を表示 / 全
-                        <%= @rooms_all.count %>件
-                    </div>
-                    <%= paginate @rooms %>
                 </div>
             </div>
         </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -5,8 +5,8 @@
                 <div class="room_back">
                     <div><%= @receive_user.name %>さんとのチャットルーム</div>
                     <%= render 'message' %>
-                    <input type="hidden" id="room_id" value="<%= @room_id %>">
-                    <input type="hidden" id="user_id" value="<%= @user_id %>">
+                    <input type="hidden" id="room_id" value="<%= @room.id %>">
+                    <input type="hidden" id="user_id" value="<%= @current_user.id %>">
                     <input type="hidden" id="receive_user_id" value="<%= @receive_user_id %>">
                 </div>
             </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -84,6 +84,7 @@
                 <%= link_to "退会する", user_registration_path, method: :delete, data: {confirm:"退会しますか？"}, class:"btn btn-danger btn-md" %>
             <% end %>
           </div>
+          <div id="push">＊通知設定はこちらから</div>
         </div>
       </div>
     </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,7 +29,7 @@
         </div>
 
         <div class="search_result_back">
-            <div class="search_result">
+            <div class="index_white_back">
                 <div class="page_count">
                     <% if @users.count == 0 %>0 〜
                     <% else %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,16 +7,11 @@
                 <div class="float_window">
                     <span>最近の投稿</span>
                     <table class="table table-hover">
-                        <% @rooms.each do |room| %>
-                            <% break if @count == 3 %>
-                            <% if message = room.messages.order(created_at: :desc).first %>
-                                <% @count += 1 %>
-                                <tr>
-                                    <% if room.host_id == current_user.id %>
-                                        <% user = User.where(id: room.member_id).first %>
-                                    <% else %>
-                                        <% user = User.where(id: room.host_id).first %>
-                                    <% end %>
+                        <% if @rooms.empty? == false %>
+                            <tr>
+                                <% room = @new_message.room %>
+                                <% if room.host_id == current_user.id %>
+                                    <% user = User.where(id: room.member_id).first %>
                                     <td class="col-xs-1">
                                         <%= link_to room_path(room) do %>
                                             <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
@@ -24,14 +19,74 @@
                                     </td>
                                     <td>
                                         <%= link_to room_path(room) do %>
-                                            <%= user.name %>
+                                            <span class="name"><%= user.name %></span>
+                                        <% end %>
+                                    </td>
+                                <% else %>
+                                    <% user = User.where(id: room.host_id).first %>
+                                    <td class="col-xs-1">
+                                        <%= link_to room_path(room) do %>
+                                            <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
                                         <% end %>
                                     </td>
                                     <td>
-                                        <div class="time"><%= message.created_at.strftime('%m/%d %H:%M') %></div>
-                                        <div id="new_message"><%= message.content.truncate(20) %></div>
+                                        <%= link_to room_path(room) do %>
+                                            <span class="name"><%= user.name %></span>
+                                        <% end %>
+                                    </td>
+                                <% end %>
+                                <td>
+                                    <%= link_to room_path(room) do %>
+                                        <div class="time"><%= @new_message.created_at.strftime('%m/%d %H:%M') %></div>
+                                        <div id="new_message"><%= @new_message.content.truncate(20) %></div>
+                                    <% end %>
+                                </td>
+                            </tr>
+                            <% room_id = @new_message.room_id %>
+                            <% old_message = @user_messages.where.not(room_id: room_id) %>
+                            <% message = old_message.order(created_at: :desc).first %>
+
+                            <% limit = 0 %>
+                            <% while old_message.count > 0 %>
+                                <% limit += 1 %>
+                                <% break if limit == 3 %>
+                                <tr>
+                                    <% room = message.room %>
+                                    <% if room.host_id == current_user.id %>
+                                        <% user = User.where(id: room.member_id).first %>
+                                        <td class="col-xs-1">
+                                            <%= link_to room_path(room) do %>
+                                                <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                            <% end %>
+                                        </td>
+                                        <td>
+                                            <%= link_to room_path(room) do %>
+                                                <span class="name"><%= user.name %></span>
+                                            <% end %>
+                                        </td>
+                                    <% else %>
+                                        <% user = User.where(id: room.host_id).first %>
+                                        <td class="col-xs-1">
+                                            <%= link_to room_path(room) do %>
+                                                <%= attachment_image_tag(user, :user_image, :fill, 40, 40, fallback: "no_image.jpg", size: "40x40") %>
+                                            <% end %>
+                                        </td>
+                                        <td>
+                                            <%= link_to room_path(room) do %>
+                                                <span class="name"><%= user.name %></span>
+                                            <% end %>
+                                        </td>
+                                    <% end %>
+                                    <td>
+                                        <%= link_to room_path(room) do %>
+                                            <div class="time"><%= message.created_at.strftime('%m/%d %H:%M') %></div>
+                                            <div id="new_message"><%= message.content.truncate(20) %></div>
+                                        <% end %>
                                     </td>
                                 </tr>
+                                <% room_id = message.room_id %>
+                                <% old_message = old_message.where.not(room_id: room_id) %>
+                                <% message = old_message.order(created_at: :desc).first %>
                             <% end %>
                         <% end %>
                     </table>
@@ -104,11 +159,15 @@
                         <% if @user == current_user %>
                             <%= link_to "編集する", edit_user_path, class:"btn btn-primary btn-md" %>
                         <% else %>
-                            <%= link_to "チャットしてみる", room_path(@user), method: :post, class:"btn btn-primary btn-md" %>
+                            <% if user_signed_in? %>
+                                <%= link_to "チャットしてみる", room_path(@user), method: :post, class:"btn btn-primary btn-md" %>
+                            <% else %>
+                                <%= link_to "チャットしてみる", new_user_session_path, class:"btn btn-primary btn-md" %>
+                            <% end %>
                         <% end %>
                     <% else %>
                         <div class="btn btn-warning btn-md">チャット不可</div>
-                    <% end %>       
+                    <% end %>
                 </div>
             </div>
         </div>

--- a/db/migrate/20200325180318_add_column_to_message.rb
+++ b/db/migrate/20200325180318_add_column_to_message.rb
@@ -2,5 +2,6 @@ class AddColumnToMessage < ActiveRecord::Migration[5.2]
   def change
     add_column :messages, :user_id, :integer
     add_column :messages, :room_id, :integer
+    add_column :messages, :receiver_id, :integer
   end
 end

--- a/db/migrate/20200325182624_change_column_to_message.rb
+++ b/db/migrate/20200325182624_change_column_to_message.rb
@@ -2,5 +2,6 @@ class ChangeColumnToMessage < ActiveRecord::Migration[5.2]
   def change
     change_column_null :messages, :user_id, false
     change_column_null :messages, :room_id, false
+    change_column_null :messages, :receiver_id, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_03_25_182624) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.integer "room_id", null: false
+    t.integer "receiver_id", null: false
   end
 
   create_table "prefectures", force: :cascade do |t|


### PR DESCRIPTION
・users/showとrooms/indexのチャット一覧表示をメッセージの更新順に表示できるように修正した。
・プッシュ通知をユーザ情報の編集画面から設定するように修正した。
・ユーザがチャットルーム以外のviewを開いていると、プッシュ通知が受信されない不具合があったため、
　チャットルーム以外のview上でもプッシュ通知を受信できるように修正した。