### PR TITLE
[fix] ルートの修正

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -3,17 +3,17 @@ class RoomsController < ApplicationController
   before_action :baria_room, only: [:show]
 
   def create
-    check_host = Room.where(host_id: current_user.id, member_id: params[:id]).exists?
-    check_member = Room.where(host_id: params[:id], member_id: current_user.id).exists?
+    check_host = Room.where(host_id: current_user.id, member_id: params[:user_id]).exists?
+    check_member = Room.where(host_id: params[:user_id], member_id: current_user.id).exists?
     if check_host || check_member == true
-      if Room.where(host_id: current_user.id, member_id: params[:id]).exists? == false
-        room = Room.where(host_id: params[:id], member_id: current_user.id).first
+      if Room.where(host_id: current_user.id, member_id: params[:user_id]).exists? == false
+        room = Room.where(host_id: params[:user_id], member_id: current_user.id).first
       else
-        room = Room.where(host_id: current_user.id, member_id: params[:id]).first
+        room = Room.where(host_id: current_user.id, member_id: params[:user_id]).first
       end
     else
-      room = Room.new(host_id: current_user.id, member_id: params[:id])
-      room.save     
+      room = Room.new(host_id: current_user.id, member_id: params[:user_id])
+      room.save
     end
     redirect_to room_path(room)
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -167,7 +167,7 @@
                   </tr>
                 <% end %>
               </table>
-              <%= link_to user_relationships_index_path, class:"btn btn-primary" do %>
+              <%= link_to user_relationships_path, class:"btn btn-primary" do %>
                 <span>お気に入りを全件表示する</span>
               <% end %>
             </div>
@@ -251,7 +251,7 @@
                 <div class="btn btn-default btn-md">チャット不可</div>
               <% else %>
                 <% if user_signed_in? %>
-                  <%= link_to "チャットしてみる", room_path(@user), method: :post, class:"btn btn-primary btn-md" %>
+                  <%= link_to "チャットしてみる", user_rooms_path(@user), method: :post, class:"btn btn-primary btn-md" %>
                 <% else %>
                   <%= link_to "チャットしてみる", new_user_registration_path, class:"btn btn-primary btn-md", data: {confirm: "チャットをするには会員登録が必要です"} %>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,25 +1,14 @@
 Rails.application.routes.draw do
-  get 'user_relationships/create'
-  get 'user_relationships/destroy'
-  get 'relationships/create'
-  get 'relationships/destroy'
-  devise_for :users
+  get "top", to: "abouts#top"
   root "abouts#top"
-  resources :rooms, only: [:show, :index] do
-    member do
-      post :create
-    end
-  end
-  
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  devise_for :users
   resources :users, only: [:index, :show, :edit, :update,] do
     resource :user_relationships, only: [:create, :destroy]
-    get :follows, on: :member
-    get :followers, on: :member
+    resources :rooms, only: [:create]
   end
-  get 'user_relationships/index'
-
-  get "top", to: "abouts#top"
+  resources :rooms, only: [:show, :index]  
+  resources :user_relationships, only: [:index]
 
   mount ActionCable.server => "/cable"
+  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION

roomsコントローラのcreateアクションはparamsでuser_idを取得していたが、
rooms/:idとして取得していたため、userにネストさせてusers/:user_id/roomsに修正した。

user_relationshipsのpathがuser_relationships_index_pathになっていたため、
user_relationships_pathに修正した。

不要なルートがあったため、削除した。