### PR TITLE
[fix] ジャンルの表示修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,7 +39,7 @@ $(function(){
     if (!('Notification' in window)) {
         alert('お使いのブラウザは通知機能非対応です');
       }else{
-        alert("ブラウザの通知設定を有効にすることで、チャットメッセージを受信した時に、プッシュ通知を受け取ることができます。(ブラウザによっては通知を受け取れない場合があります。)");
+        alert("ブラウザの通知設定を有効にすることで、\nチャットメッセージを受信した時に、\nプッシュ通知を受け取ることができます。\n\n(ブラウザによっては通知を受け取れない場合があります。)");
         Notification.requestPermission()
         .then((permission) => {
         if (permission == 'granted') {

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -40,14 +40,17 @@
                 Level.<%= user.level %>
               <% end %>
             </span>
-
-            <% limit = 0 %>
+            <% limit = 3 %>
             <% user.genres. each do |genre| %>
-              <% break if limit == 3 %>
-              <% limit += 1 %>
+              <% break if limit == 0 %>
+              <% limit -= 1 %>
               <span class="genre_icon"><%= genre.genre_name %></span>
             <% end %>
+            <% limit.times do %>
+              <span class="genre_icon">未登録</span>
+            <% end %>
           <% end %>
+
           <% following = user %>
           <span id="follow_<%= following.id %>">
             <%= render partial:"layouts/follow", locals: {following: following} %>

--- a/app/views/user_relationships/index.html.erb
+++ b/app/views/user_relationships/index.html.erb
@@ -36,11 +36,14 @@
                         <% end %>
                       </span>
 
-                      <% limit = 0 %>
+                      <% limit = 3 %>
                       <% following.genres. each do |genre| %>
-                        <% break if limit == 3 %>
-                        <% limit += 1 %>
+                        <% break if limit == 0 %>
+                        <% limit -= 1 %>
                         <span class="genre_icon"><%= genre.genre_name %></span>
+                      <% end %>
+                      <% limit.times do %>
+                        <span class="genre_icon">未登録</span>
                       <% end %>
                     <% end %>
                     <span id="follow_<%= following.id %>">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -143,13 +143,17 @@
                             <% end %>
                           </span>
 
-                          <% limit = 0 %>
-                          <% following.genres. each do |genre| %>
-                            <% break if limit == 2 %>
-                            <% limit += 1 %>
-                            <span class="genre_icon"><%= genre.genre_name %></span>
+                          <% limit = 2 %>
+                            <% user.genres. each do |genre| %>
+                              <% break if limit == 0 %>
+                              <% limit -= 1 %>
+                              <span class="genre_icon"><%= genre.genre_name %></span>
+                            <% end %>
+                            <% limit.times do %>
+                              <span class="genre_icon">未登録</span>
+                            <% end %>
                           <% end %>
-                        <% end %>
+                        
                         <span id="follow_<%= following.id %>">
                           <%= render partial:"layouts/follow", locals: {following: following} %>
                         </span>


### PR DESCRIPTION
ジャンルの登録数が少ないとレイアウトが崩れることが分かったため、
登録数が少ない時には、未登録の文字を表示させるように修正した。

通知設定のメッセージが見にくかったため、改行させた。