### PR TITLE
[fix] ジャンルの表示エラー修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -144,7 +144,7 @@
                           </span>
 
                           <% limit = 2 %>
-                            <% user.genres. each do |genre| %>
+                            <% following.genres. each do |genre| %>
                               <% break if limit == 0 %>
                               <% limit -= 1 %>
                               <span class="genre_icon"><%= genre.genre_name %></span>


### PR DESCRIPTION
ユーザshowページに表示される、お気に入り登録したユーザのジャンル表示が、
Roomテーブルのhost_idに紐づいたものになっていたため、お気に入り登録したユーザに
紐づいたジャンルの表示に修正した。